### PR TITLE
Opt empty constructor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin"
 apply plugin: 'org.jetbrains.dokka'
 
 group 'org.godwin'
-version '1.6'
+version '1.7'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/kdocer/SettingsPanel.form
+++ b/src/main/java/com/kdocer/SettingsPanel.form
@@ -134,7 +134,7 @@
               </component>
             </children>
           </grid>
-          <grid id="557ea" binding="generalOtherPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="557ea" binding="generalOtherPanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -146,7 +146,7 @@
             <children>
               <component id="b3a97" class="javax.swing.JCheckBox" binding="generalOtherOverriddenMethodsCheckbox">
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Comment overridden methods"/>
@@ -154,7 +154,7 @@
               </component>
               <component id="95428" class="javax.swing.JCheckBox" binding="generalOtherSplittedClassName">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <selected value="true"/>
@@ -163,7 +163,7 @@
               </component>
               <component id="9d1a8" class="javax.swing.JCheckBox" binding="disableNotification">
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Disable notifications"/>
@@ -171,7 +171,7 @@
               </component>
               <component id="dc294" class="javax.swing.JTextField" binding="lblInfo">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -181,7 +181,7 @@
               </component>
               <component id="550d7" class="javax.swing.JLabel" binding="lblInfoDonate">
                 <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <foreground color="-16579653"/>
@@ -190,11 +190,20 @@
               </component>
               <component id="89018" class="javax.swing.JLabel" binding="lblInfoRate">
                 <constraints>
-                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <foreground color="-16579653"/>
                   <text value="Give a star"/>
+                </properties>
+              </component>
+              <component id="4806" class="javax.swing.JCheckBox" binding="generalOtherEmptyConstructor">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <selected value="true"/>
+                  <text value="Enable KDoc empty constructor"/>
                 </properties>
               </component>
             </children>

--- a/src/main/java/com/kdocer/SettingsPanel.java
+++ b/src/main/java/com/kdocer/SettingsPanel.java
@@ -50,6 +50,10 @@ public class SettingsPanel {
      */
     private JPanel generalOtherPanel;
     /**
+     * The General Other Enable Empty Constructor checkbox.
+     */
+    private JCheckBox generalOtherEmptyConstructor;
+    /**
      * The General other overridden methods checkbox.
      */
     private JCheckBox generalOtherOverriddenMethodsCheckbox;
@@ -85,6 +89,7 @@ public class SettingsPanel {
     private JTextField lblInfo;
     private JLabel lblInfoDonate;
     private JLabel lblInfoRate;
+    private JCheckBox generalOtherEnableEmptyConstructor;
 
     private ConfigCallback callback;
 
@@ -310,6 +315,20 @@ public class SettingsPanel {
     public void setSplittedClassNames(boolean splittedClassNames) {
         generalOtherSplittedClassName.setSelected(splittedClassNames);
     }
+
+    /**
+     * Is allowed empty constructor
+     * @return the boolean
+     */
+    public boolean isAllowedEmptyConstructor() { return generalOtherEmptyConstructor.isSelected(); }
+
+    /**
+     * Sets allowed empty constructor
+     *
+     * @param isAllowed the is allowed
+     */
+    public void setAllowedEmptyConstructor(boolean isAllowed) { generalOtherEmptyConstructor.setSelected(isAllowed); }
+
 
     /**
      * Is allowed class boolean.

--- a/src/main/kotlin/com/kdocer/generator/ClassKDocGenerator.kt
+++ b/src/main/kotlin/com/kdocer/generator/ClassKDocGenerator.kt
@@ -1,6 +1,7 @@
 package com.kdocer.generator
 
 import com.intellij.openapi.project.Project
+import com.kdocer.service.KDocerSettings
 import com.kdocer.util.Validator
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
@@ -15,6 +16,7 @@ internal class ClassKDocGenerator(private val project: Project, private val elem
     KDocGenerator {
 
     override fun generate(): String {
+        val settings = KDocerSettings.getInstance()
         val builder = StringBuilder()
         val name = if (Validator.isNameNeedsSplit()) nameToPhrase(element.name ?: "Class") else element.name
         builder.appendLine("/**")
@@ -39,7 +41,9 @@ internal class ClassKDocGenerator(private val project: Project, private val elem
                 .appendLine("*")
                 .appendLine(toParamsKdoc(params = parameters))
         } else {
-            builder.appendLine("* @constructor Create empty $name")
+            if (settings.isAllowedEmptyConstructor) {
+                builder.appendLine("* @constructor Create empty $name")
+            }
         }
         builder.appendLine("*/")
         return builder.toString()

--- a/src/main/kotlin/com/kdocer/service/KDocerConfigurable.kt
+++ b/src/main/kotlin/com/kdocer/service/KDocerConfigurable.kt
@@ -32,7 +32,8 @@ class KDocerConfigurable : Configurable {
                 settings.isSplittedClassNames != componet.isSplittedClassNames ||
                 settings.isAllowedKeepDoc != componet.isAllowedKeepDoc ||
                 settings.isAllowedReplaceDoc != componet.isAllowedReplaceDoc ||
-                settings.isDisabledNotification != componet.isDisabledNotification
+                settings.isDisabledNotification != componet.isDisabledNotification ||
+                settings.isAllowedEmptyConstructor != componet.isAllowedEmptyConstructor
     }
 
     override fun getDisplayName(): String {
@@ -54,6 +55,7 @@ class KDocerConfigurable : Configurable {
         settings.isAllowedKeepDoc = componet.isAllowedKeepDoc
         settings.isAllowedReplaceDoc = componet.isAllowedReplaceDoc
         settings.isDisabledNotification = componet.isDisabledNotification
+        settings.isAllowedEmptyConstructor = componet.isAllowedEmptyConstructor
 
 //        if (settings.isDisabledNotification) {
 //            settings.lastShowedTime = time
@@ -77,6 +79,7 @@ class KDocerConfigurable : Configurable {
         componet.isAllowedKeepDoc = settings.isAllowedKeepDoc
         componet.isAllowedReplaceDoc = settings.isAllowedReplaceDoc
         componet.isDisabledNotification = settings.isDisabledNotification
+        componet.isAllowedEmptyConstructor = settings.isAllowedEmptyConstructor
 
 //        if (settings.isDisabledNotification) {
 //            val lastDisabledTime = settings.lastShowedTime

--- a/src/main/kotlin/com/kdocer/service/KDocerSettings.kt
+++ b/src/main/kotlin/com/kdocer/service/KDocerSettings.kt
@@ -45,6 +45,8 @@ class KDocerSettings : PersistentStateComponent<KDocerSettings> {
     var lastShowedTime: Long = 0L
     var isDisabledNotification: Boolean = false
 
+    var isAllowedEmptyConstructor: Boolean = true  // for backward compatible behavior
+
     override fun getState(): KDocerSettings? {
         return this
     }


### PR DESCRIPTION
Add option to suppress documenting the empty constructor on a class or interface, as noted in #8.

The option is 'enable empty constructor' and defaults to `true`, for backward compatibility.
Set it to `false` (clear the checkbox) and the plugin will not generate the extra comment line "* create empty _name_", even if a custom coded constructor with no parameters is present in the class or interface definition.