### PR TITLE
Add append name setting

### DIFF
--- a/src/main/java/com/kdocer/SettingsPanel.form
+++ b/src/main/java/com/kdocer/SettingsPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="974" height="400"/>
+      <xy x="20" y="20" width="974" height="434"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -134,7 +134,7 @@
               </component>
             </children>
           </grid>
-          <grid id="557ea" binding="generalOtherPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="557ea" binding="generalOtherPanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -163,7 +163,7 @@
               </component>
               <component id="9d1a8" class="javax.swing.JCheckBox" binding="disableNotification">
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Disable notifications"/>
@@ -171,7 +171,7 @@
               </component>
               <component id="dc294" class="javax.swing.JTextField" binding="lblInfo">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -181,7 +181,7 @@
               </component>
               <component id="550d7" class="javax.swing.JLabel" binding="lblInfoDonate">
                 <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <foreground color="-16579653"/>
@@ -190,11 +190,21 @@
               </component>
               <component id="89018" class="javax.swing.JLabel" binding="lblInfoRate">
                 <constraints>
-                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <foreground color="-16579653"/>
                   <text value="Give a star"/>
+                </properties>
+              </component>
+              <component id="9ab98" class="javax.swing.JCheckBox" binding="generalOtherAppendName">
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <selected value="true"/>
+                  <text value="Append function/class names in generated Docs"/>
+                  <toolTipText value="When enabled, the first line of your KDoc will be the generated function name or class name"/>
                 </properties>
               </component>
             </children>

--- a/src/main/java/com/kdocer/SettingsPanel.java
+++ b/src/main/java/com/kdocer/SettingsPanel.java
@@ -58,6 +58,10 @@ public class SettingsPanel {
      */
     private JCheckBox generalOtherSplittedClassName;
     /**
+     * The General other append name.
+     */
+    private JCheckBox generalOtherAppendName;
+    /**
      * The General panel.
      */
     private JPanel generalPanel;
@@ -291,6 +295,24 @@ public class SettingsPanel {
      */
     public void setAllowedReplaceDoc(boolean allowedReplaceDoc) {
         generalModeKeepRadioButton.setSelected(allowedReplaceDoc);
+    }
+
+    /**
+     * Is append name boolean.
+     *
+     * @return the boolean
+     */
+    public boolean isAppendName() {
+        return generalOtherAppendName.isSelected();
+    }
+
+    /**
+     * Sets append name.
+     *
+     * @param appendName the append name
+     */
+    public void setAppendName(boolean appendName) {
+        generalOtherAppendName.setSelected(appendName);
     }
 
     /**

--- a/src/main/kotlin/com/kdocer/EnterAfterKDocGenHandler.kt
+++ b/src/main/kotlin/com/kdocer/EnterAfterKDocGenHandler.kt
@@ -68,7 +68,7 @@ class EnterAfterKDocGenHandler : EnterHandlerDelegateAdapter() {
                         .let { CodeStyleManager.getInstance(project).reformat(it) }
                 }?.let {
                     it.getChildOfType<KDocSection>()?.let {
-                        caretModel.moveToOffset(it.textOffset + 6)
+                        caretModel.moveToOffset(it.textOffset + 1) // Move caret onto the first line
                     }
                 }
         }

--- a/src/main/kotlin/com/kdocer/generator/ClassKDocGenerator.kt
+++ b/src/main/kotlin/com/kdocer/generator/ClassKDocGenerator.kt
@@ -17,8 +17,9 @@ internal class ClassKDocGenerator(private val project: Project, private val elem
     override fun generate(): String {
         val builder = StringBuilder()
         val name = if (Validator.isNameNeedsSplit()) nameToPhrase(element.name ?: "Class") else element.name
+        val isAppendName = Validator.isAppendName()
         builder.appendLine("/**")
-            .appendLine("* $name")
+            .append("* ").apply { if (isAppendName) append(name) }.appendLine()
             .appendLine("*")
 
         if (element.typeParameters.isNotEmpty()) {

--- a/src/main/kotlin/com/kdocer/generator/KDocGenerator.kt
+++ b/src/main/kotlin/com/kdocer/generator/KDocGenerator.kt
@@ -15,7 +15,7 @@ interface KDocGenerator {
         params.map { "$keyword ${it.name}" }
             .joinToString(LF, transform = { "* $it" })
 
-    fun StringBuilder.appendLine(text: String): StringBuilder = append(text).append(LF)
+    fun StringBuilder.appendLine(text: String = ""): StringBuilder = append(text).append(LF)
 
 
     /**

--- a/src/main/kotlin/com/kdocer/generator/NamedFunctionKDocGenerator.kt
+++ b/src/main/kotlin/com/kdocer/generator/NamedFunctionKDocGenerator.kt
@@ -11,8 +11,9 @@ class NamedFunctionKDocGenerator(private val project: Project, private val eleme
 
         val builder = StringBuilder()
         val nameToPhrase = if (Validator.isNameNeedsSplit()) nameToPhrase(element.name ?: "Function") else element.name
+        val isAppendName = Validator.isAppendName()
         builder.appendLine("/**")
-            .appendLine("* $nameToPhrase")
+            .append("* ").apply { if (isAppendName) append(nameToPhrase) }.appendLine()
             .appendLine("*")
 
         if (element.typeParameters.isNotEmpty()) {

--- a/src/main/kotlin/com/kdocer/generator/NamedFunctionKDocGenerator.kt
+++ b/src/main/kotlin/com/kdocer/generator/NamedFunctionKDocGenerator.kt
@@ -8,10 +8,16 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 class NamedFunctionKDocGenerator(private val project: Project, private val element: KtNamedFunction) :
     KDocGenerator {
     override fun generate(): String {
+        val isAppendName = Validator.isAppendName()
+
+        // Return an empty KDoc, if applicable
+        val isEmpty = !isAppendName && element.typeParameters.isEmpty() && element.valueParameters.isEmpty()
+                && (element.typeReference?.text ?: "Unit") == "Unit"
+        if (isEmpty)
+            return "/**\n * \n */\n"
 
         val builder = StringBuilder()
         val nameToPhrase = if (Validator.isNameNeedsSplit()) nameToPhrase(element.name ?: "Function") else element.name
-        val isAppendName = Validator.isAppendName()
         builder.appendLine("/**")
             .append("* ").apply { if (isAppendName) append(nameToPhrase) }.appendLine()
             .appendLine("*")

--- a/src/main/kotlin/com/kdocer/generator/PropertyKDocGenerator.kt
+++ b/src/main/kotlin/com/kdocer/generator/PropertyKDocGenerator.kt
@@ -7,10 +7,15 @@ import org.jetbrains.kotlin.psi.KtProperty
 class PropertyKDocGenerator(private val project: Project, private val element: KtProperty) :
     KDocGenerator {
     override fun generate(): String {
+        val isAppendName = Validator.isAppendName()
+
+        // Return an empty KDoc, if applicable
+        val isEmpty = !isAppendName
+        if (isEmpty)
+            return "/**\n *\n */\n"
 
         val builder = StringBuilder()
         val nameToPhrase = if (Validator.isNameNeedsSplit()) nameToPhrase(element.name ?: "Property") else element.name
-        val isAppendName = Validator.isAppendName()
         builder.appendLine("/**")
             .append("* ").apply { if (isAppendName) append(nameToPhrase) }.appendLine()
 //            .appendLine("*")

--- a/src/main/kotlin/com/kdocer/generator/PropertyKDocGenerator.kt
+++ b/src/main/kotlin/com/kdocer/generator/PropertyKDocGenerator.kt
@@ -10,8 +10,9 @@ class PropertyKDocGenerator(private val project: Project, private val element: K
 
         val builder = StringBuilder()
         val nameToPhrase = if (Validator.isNameNeedsSplit()) nameToPhrase(element.name ?: "Property") else element.name
+        val isAppendName = Validator.isAppendName()
         builder.appendLine("/**")
-            .appendLine("* $nameToPhrase")
+            .append("* ").apply { if (isAppendName) append(nameToPhrase) }.appendLine()
 //            .appendLine("*")
 
 //        if (element.typeParameters.isNotEmpty()) {

--- a/src/main/kotlin/com/kdocer/service/KDocerConfigurable.kt
+++ b/src/main/kotlin/com/kdocer/service/KDocerConfigurable.kt
@@ -30,6 +30,7 @@ class KDocerConfigurable : Configurable {
                 settings.isAllowedField != componet.isAllowedField ||
                 settings.isAllowedFun != componet.isAllowedFun ||
                 settings.isSplittedClassNames != componet.isSplittedClassNames ||
+                settings.isAppendName != componet.isAppendName ||
                 settings.isAllowedKeepDoc != componet.isAllowedKeepDoc ||
                 settings.isAllowedReplaceDoc != componet.isAllowedReplaceDoc ||
                 settings.isDisabledNotification != componet.isDisabledNotification
@@ -51,6 +52,7 @@ class KDocerConfigurable : Configurable {
         settings.isAllowedField = componet.isAllowedField
         settings.isAllowedFun = componet.isAllowedFun
         settings.isSplittedClassNames = componet.isSplittedClassNames
+        settings.isAppendName = componet.isAppendName
         settings.isAllowedKeepDoc = componet.isAllowedKeepDoc
         settings.isAllowedReplaceDoc = componet.isAllowedReplaceDoc
         settings.isDisabledNotification = componet.isDisabledNotification
@@ -74,6 +76,7 @@ class KDocerConfigurable : Configurable {
         componet.isAllowedField = settings.isAllowedField
         componet.isAllowedFun = settings.isAllowedFun
         componet.isSplittedClassNames = settings.isSplittedClassNames
+        componet.isAppendName = settings.isAppendName
         componet.isAllowedKeepDoc = settings.isAllowedKeepDoc
         componet.isAllowedReplaceDoc = settings.isAllowedReplaceDoc
         componet.isDisabledNotification = settings.isDisabledNotification

--- a/src/main/kotlin/com/kdocer/service/KDocerSettings.kt
+++ b/src/main/kotlin/com/kdocer/service/KDocerSettings.kt
@@ -37,6 +37,7 @@ class KDocerSettings : PersistentStateComponent<KDocerSettings> {
 
     var isAllowedOverride: Boolean = false
     var isSplittedClassNames: Boolean = true
+    var isAppendName: Boolean = true
 
     var isAllowedClass: Boolean = true
     var isAllowedFun: Boolean = true

--- a/src/main/kotlin/com/kdocer/util/Validator.kt
+++ b/src/main/kotlin/com/kdocer/util/Validator.kt
@@ -63,4 +63,9 @@ object Validator {
         val settings = KDocerSettings.getInstance()
         return settings.isSplittedClassNames
     }
+
+    fun isAppendName(): Boolean {
+        val settings = KDocerSettings.getInstance()
+        return settings.isAppendName
+    }
 }


### PR DESCRIPTION
Thanks for making this plugin, it has saved me a good hunk of time!

Except, I am not a fan of the auto generated names... They are a bit clunky. The caret position is off (which this PR fixes), and I always find myself deleting them anyway. It would be more efficient if there was an option to skip the default names.

So I added this option `Append function/class names...`:
![image](https://github.com/godwinjk/KDoc-er/assets/43940682/7d54a641-5b15-412d-8655-c39005040dc7)

Which is enabled by default. When we disable it, the names of properties, classes, and functions are not included in the KDoc. This introduced a new issue... empty kdocs. It generates something like:
```kotlin
/**
 *
 *
 */
```
So I added a check at the beginning to ensure empty KDocs are written as:
```kotlin
/**
 *
 */
```

A better solution in the future would be to allow people to input a template, so they can add/remove all variables as they want. 



